### PR TITLE
Feature/improve cs fixer config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: docker://oskarstark/php-cs-fixer-ga
         name: PHP-CS-Fixer
         with:
-          args: --allow-risky=yes --diff --dry-run
+          args: --diff --dry-run

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -13,9 +13,45 @@ return PhpCsFixer\Config::create()
     ->setLineEnding("\n") // Linux LF line ending
     ->setRiskyAllowed(true)
     ->setRules([
-        '@Symfony' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'declare_strict_types' => true,
+        '@PhpCsFixer' => true,
+        '@PHP70Migration' => true,
+        '@PHP71Migration:risky' => true,
+        '@PHP71Migration' => true,
+        '@PHP71Migration:risky' => true,
+        '@PHP73Migration' => true,
+
+        'ordered_class_elements' => [
+            'order' => [
+                'use_trait', // traits
+
+                'constant_public', // constants
+                'constant_protected',
+                'constant_private',
+
+                'property_public_static', // static properties
+                'property_protected_static',
+                'property_private_static',
+
+                'property_public', // properties
+                'property_protected',
+                'property_private',
+
+                'construct', // magic methods
+                'destruct',
+                'magic',
+
+                'method_public_static', // static methods
+                'method_protected_static',
+                'method_private_static',
+
+                'method_public', // methods
+                'method_protected',
+                'method_private',
+
+                'phpunit', // PHPUnit
+            ],
+            'sortAlgorithm' => 'none',
+        ],
     ])
     ->setFinder($finder)
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 $finder = PhpCsFixer\Finder::create()
     ->exclude('var')
+    ->exclude('node_modules')
     ->notPath('config/bundles.php')
     ->in(__DIR__)
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,6 +11,7 @@ $finder = PhpCsFixer\Finder::create()
 
 return PhpCsFixer\Config::create()
     ->setLineEnding("\n") // Linux LF line ending
+    ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -10,6 +10,7 @@ $finder = PhpCsFixer\Finder::create()
 ;
 
 return PhpCsFixer\Config::create()
+    ->setLineEnding("\n") // Linux LF line ending
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
             "@auto-scripts"
         ],
         "cs": [
-            "php vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --allow-risky=yes"
+            "php vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix"
         ]
     },
     "conflict": {


### PR DESCRIPTION
Based on: https://github.com/ArmaForces/Website/pull/3

This will improve CS Fixer ruleset by adding additional formatting rules for PHP 7+ and some additional configuration options.

Also `--allow-risky=yes` pramater here:
https://github.com/ArmaForces/Website/blob/dev/.github/workflows/lint.yml#L14
shouldn't be needed anymore but I cannot modify workflow config from PR.