### PR TITLE
Fetch user avatar hash on subsequent logins

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -4,7 +4,7 @@ security:
         users:
             entity:
                 # the class of the entity that represents users
-                class: 'App\Entity\User\User'
+                class: 'App\Entity\User\UserEntity'
                 # the property to query by - e.g. username, email, etc
                 property: 'externalId'
 

--- a/src/Security/DiscordAuthenticator.php
+++ b/src/Security/DiscordAuthenticator.php
@@ -114,13 +114,13 @@ class DiscordAuthenticator extends SocialAuthenticator
         try {
             $user = $userProvider->loadUserByUsername($externalId);
             $user->setAvatarHash($discordResourceOwner->getAvatarHash());
-            $this->em->flush();
         } catch (UsernameNotFoundException $ex) {
             $user = new UserEntity($email, $email, $externalId);
             $user->setAvatarHash($discordResourceOwner->getAvatarHash());
             $this->em->persist($user);
-            $this->em->flush();
         }
+        
+        $this->em->flush();
 
         return $user;
     }

--- a/src/Security/DiscordAuthenticator.php
+++ b/src/Security/DiscordAuthenticator.php
@@ -112,6 +112,7 @@ class DiscordAuthenticator extends SocialAuthenticator
         $externalId = $discordResourceOwner->getId();
 
         try {
+            /** @var UserEntity $user */
             $user = $userProvider->loadUserByUsername($externalId);
             $user->setAvatarHash($discordResourceOwner->getAvatarHash());
         } catch (UsernameNotFoundException $ex) {

--- a/src/Security/DiscordAuthenticator.php
+++ b/src/Security/DiscordAuthenticator.php
@@ -119,7 +119,7 @@ class DiscordAuthenticator extends SocialAuthenticator
             $user->setAvatarHash($discordResourceOwner->getAvatarHash());
             $this->em->persist($user);
         }
-        
+
         $this->em->flush();
 
         return $user;

--- a/src/Security/DiscordAuthenticator.php
+++ b/src/Security/DiscordAuthenticator.php
@@ -113,6 +113,8 @@ class DiscordAuthenticator extends SocialAuthenticator
 
         try {
             $user = $userProvider->loadUserByUsername($externalId);
+            $user->setAvatarHash($discordResourceOwner->getAvatarHash());
+            $this->em->flush();
         } catch (UsernameNotFoundException $ex) {
             $user = new UserEntity($email, $email, $externalId);
             $user->setAvatarHash($discordResourceOwner->getAvatarHash());


### PR DESCRIPTION
- title
- does not solve the invisible avatar issue if user changed avatar while still logged in on website