### PR TITLE
Change validation level to 6 due to how SF forms works

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
             "php vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix"
         ],
         "stan": [
-            "php vendor/phpstan/phpstan/phpstan analyse --level=max src"
+            "php vendor/phpstan/phpstan/phpstan analyse --level=6 src"
         ],
         "lint": [
             "php bin/console lint:twig templates/",


### PR DESCRIPTION
This will:
Change validation strictness to allow using nullable values in non nullable arguments.
https://gist.github.com/carusogabriel/62698312f451589afd956eddac2dc07a#level-7