### PR TITLE
Fix translations lint warning

### DIFF
--- a/templates/home/index/_partial/_missions.html.twig
+++ b/templates/home/index/_partial/_missions.html.twig
@@ -16,7 +16,7 @@
         {% if nearestMission is not null %}
             <!--Grid column-->
             <div class="col-lg-4 col-md-6">
-                    <h4 class="my-4 font-weight-bold">{{ (nearestMission.archived ? 'Last mission' : 'Nearest mission')|trans }}</h4>
+                    <h4 class="my-4 font-weight-bold">{{ nearestMission.archived ? 'Last mission'|trans : 'Nearest mission'|trans }}</h4>
 
                     <div class="img-mission">
                         <img src="{{ nearestMission.image }}" alt="">


### PR DESCRIPTION
This will:
* Fix warning during translations lint caused by applying`trans` filter on condition result.
![obraz](https://user-images.githubusercontent.com/20958025/72665296-251c1180-3a07-11ea-9092-8456b8a31e2a.png)
