### PR TITLE
Adjust time range of calendar event links from -30m to +2h

### DIFF
--- a/src/Twig/CalendarExtension.php
+++ b/src/Twig/CalendarExtension.php
@@ -31,8 +31,9 @@ class CalendarExtension extends AbstractExtension
 
     protected function createMissionEventLink(MissionDto $mission): Link
     {
-        $eventDate = \DateTime::createFromImmutable($mission->getDate());
+        $fromDate = \DateTime::createFromImmutable($mission->getDate())->sub(new \DateInterval('PT30M'));
+        $toDate = \DateTime::createFromImmutable($mission->getDate())->add(new \DateInterval('PT2H'));
 
-        return Link::create($mission->getTitle(), $eventDate, $eventDate);
+        return Link::create($mission->getTitle(), $fromDate, $toDate);
     }
 }


### PR DESCRIPTION
- start mission event 30 min before mission time
- end mission event 2h after mission time