### PR TITLE
Feature/deactivate mod list

### DIFF
--- a/config/doctrine/ModList/ModList.orm.xml
+++ b/config/doctrine/ModList/ModList.orm.xml
@@ -26,6 +26,8 @@
             <join-column name="owner_id" referenced-column-name="id" nullable="true"/>
         </many-to-one>
 
+        <field name="active" type="boolean"/>
+
         <unique-constraints>
             <unique-constraint columns="name"/>
         </unique-constraints>

--- a/migrations/Version20200831200358.php
+++ b/migrations/Version20200831200358.php
@@ -22,8 +22,7 @@ final class Version20200831200358 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('ALTER TABLE mod_lists ADD active TINYINT(1) NULL');
-        $this->addSql('UPDATE mod_lists SET active=1');
+        $this->addSql('ALTER TABLE mod_lists ADD active TINYINT(1) DEFAULT 1 NULL');
         $this->addSql('ALTER TABLE mod_lists MODIFY active TINYINT(1) NOT NULL');
     }
 

--- a/migrations/Version20200831200358.php
+++ b/migrations/Version20200831200358.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200831200358 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add active property to Mod List';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE mod_lists ADD active TINYINT(1) NULL');
+        $this->addSql('UPDATE mod_lists SET active=1');
+        $this->addSql('ALTER TABLE mod_lists MODIFY active TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE mod_lists DROP active');
+    }
+}

--- a/src/Controller/ModListPublicController.php
+++ b/src/Controller/ModListPublicController.php
@@ -6,6 +6,8 @@ namespace App\Controller;
 
 use App\Entity\ModList\ModList;
 use App\Repository\ModListRepository;
+use App\Security\Enum\PermissionsEnum;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
@@ -38,6 +40,8 @@ class ModListPublicController extends AbstractController
 
     /**
      * @Route("/{name}/customize", name="_customize")
+     *
+     * @IsGranted(PermissionsEnum::MOD_LIST_DOWNLOAD, subject="modList")
      */
     public function customizeAction(ModList $modList): Response
     {
@@ -48,6 +52,8 @@ class ModListPublicController extends AbstractController
 
     /**
      * @Route("/{name}/download/{optionalModsJson}", name="_download", options={"expose": true})
+     *
+     * @IsGranted(PermissionsEnum::MOD_LIST_DOWNLOAD, subject="modList")
      */
     public function downloadAction(ModList $modList, string $optionalModsJson = null): Response
     {

--- a/src/Controller/ModListPublicController.php
+++ b/src/Controller/ModListPublicController.php
@@ -31,7 +31,7 @@ class ModListPublicController extends AbstractController
      */
     public function selectAction(): Response
     {
-        $modLists = $this->modListRepository->findBy([], ['name' => 'ASC']);
+        $modLists = $this->modListRepository->findBy(['active' => true], ['name' => 'ASC']);
 
         return $this->render('mod_list_public/select.html.twig', [
             'modLists' => $modLists,

--- a/src/Entity/ModList/ModList.php
+++ b/src/Entity/ModList/ModList.php
@@ -18,6 +18,9 @@ class ModList extends AbstractDescribedEntity implements ModListInterface
     /** @var null|UserInterface */
     protected $owner;
 
+    /** @var bool */
+    protected $active = true;
+
     public function __construct(string $name)
     {
         parent::__construct($name);
@@ -64,5 +67,15 @@ class ModList extends AbstractDescribedEntity implements ModListInterface
     public function setOwner(?UserInterface $owner): void
     {
         $this->owner = $owner;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): void
+    {
+        $this->active = $active;
     }
 }

--- a/src/Entity/ModList/ModListInterface.php
+++ b/src/Entity/ModList/ModListInterface.php
@@ -27,4 +27,8 @@ interface ModListInterface extends DescribedEntityInterface
     public function getOwner(): ?UserInterface;
 
     public function setOwner(?UserInterface $owner): void;
+
+    public function isActive(): bool;
+
+    public function setActive(bool $active): void;
 }

--- a/src/Form/ModList/DataTransformer/ModListFormDtoDataTransformer.php
+++ b/src/Form/ModList/DataTransformer/ModListFormDtoDataTransformer.php
@@ -33,6 +33,7 @@ class ModListFormDtoDataTransformer implements FormDtoDataTransformerInterface
         $entity->setDescription($dto->getDescription());
         $entity->setMods($dto->getMods());
         $entity->setOwner($dto->getOwner());
+        $entity->setActive($dto->isActive());
 
         return $entity;
     }
@@ -56,6 +57,7 @@ class ModListFormDtoDataTransformer implements FormDtoDataTransformerInterface
         $dto->setDescription($entity->getDescription());
         $dto->setMods($entity->getMods());
         $dto->setOwner($entity->getOwner());
+        $dto->setActive($entity->isActive());
 
         return $dto;
     }

--- a/src/Form/ModList/Dto/ModListFormDto.php
+++ b/src/Form/ModList/Dto/ModListFormDto.php
@@ -48,7 +48,7 @@ class ModListFormDto extends AbstractFormDto
     /**
      * @var bool
      */
-    protected $active;
+    protected $active = true;
 
     public function __construct()
     {

--- a/src/Form/ModList/Dto/ModListFormDto.php
+++ b/src/Form/ModList/Dto/ModListFormDto.php
@@ -45,6 +45,11 @@ class ModListFormDto extends AbstractFormDto
      */
     protected $owner;
 
+    /**
+     * @var bool
+     */
+    protected $active;
+
     public function __construct()
     {
         $this->mods = new ArrayCollection();
@@ -125,5 +130,15 @@ class ModListFormDto extends AbstractFormDto
     public function setOwner(?UserInterface $owner): void
     {
         $this->owner = $owner;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): void
+    {
+        $this->active = $active;
     }
 }

--- a/src/Form/ModList/ModListFormType.php
+++ b/src/Form/ModList/ModListFormType.php
@@ -11,6 +11,7 @@ use App\Form\ModList\Dto\ModListFormDto;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -67,12 +68,16 @@ class ModListFormType extends AbstractType
             $ownerTypeConfig['data'] = $currentUser;
         }
 
-        // Add owner lists only if user has full permissions to edit Mod Lists
+        // Add owner list only if user has full permissions to edit Mod Lists
         if ($currentUser->getPermissions()->getModListPermissions()->canUpdate()) {
             $builder->add('owner', EntityType::class, $ownerTypeConfig);
         }
 
         $builder
+            ->add('active', CheckboxType::class, [
+                'label' => 'Mod list active',
+                'required' => false,
+            ])
             ->add('mods', EntityType::class, [
                 'label' => 'Mods',
                 'label_attr' => ['class' => 'switch-custom'],

--- a/src/Security/Enum/PermissionsEnum.php
+++ b/src/Security/Enum/PermissionsEnum.php
@@ -16,6 +16,7 @@ class PermissionsEnum
     public const MOD_DELETE = 'mod_delete';
 
     public const MOD_LIST_LIST = 'mod_list_list';
+    public const MOD_LIST_DOWNLOAD = 'mod_list_download';
     public const MOD_LIST_CREATE = 'mod_list_create';
     public const MOD_LIST_UPDATE = 'mod_list_update';
     public const MOD_LIST_COPY = 'mod_list_copy';

--- a/src/Security/Voter/ModList/DownloadModListVoter.php
+++ b/src/Security/Voter/ModList/DownloadModListVoter.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security\Voter\ModList;
+
+use App\Entity\ModList\ModList;
+use App\Entity\ModList\ModListInterface;
+use App\Entity\User\UserInterface;
+use App\Security\Enum\PermissionsEnum;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class DownloadModListVoter extends Voter
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function supports($attribute, $subject): bool
+    {
+        return PermissionsEnum::MOD_LIST_DOWNLOAD === $attribute && $subject instanceof ModListInterface;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
+    {
+        /** @var null|UserInterface $currentUser */
+        $currentUser = $token->getUser();
+
+        /** @var ModList $modList */
+        $modList = $subject;
+
+        // User always can download active Mod List
+        if ($modList->isActive()) {
+            return true;
+        }
+
+        // Otherwise user needs to be logged-in and have "List" permission granted
+        return $currentUser instanceof UserInterface && $currentUser->getPermissions()->getModListPermissions()->canList();
+    }
+}

--- a/templates/mod_list/list.html.twig
+++ b/templates/mod_list/list.html.twig
@@ -36,7 +36,9 @@
                         <td>{{ modList.name }}</td>
                         <td>{{ modList.description }}</td>
                         <td>{{ modList.owner ? modList.owner.username : '' }}</td>
-                        <td>{{ modList.active ? 'Yes'|trans : 'No'|trans }}</td>
+                        <td class="{{ modList.active ? '' : 'text-danger' }}">
+                            {{ modList.active ? 'Yes'|trans : 'No'|trans }}
+                        </td>
                         <td>{{ tableMacro.row_blameable(modList.createdAt, modList.createdBy) }}</td>
                         <td>{{ tableMacro.row_blameable(modList.lastUpdatedAt, modList.lastUpdatedBy) }}</td>
                         <td class="text-right">

--- a/templates/mod_list/list.html.twig
+++ b/templates/mod_list/list.html.twig
@@ -22,6 +22,7 @@
                     <th scope="col">{{ 'Mod list name'|trans }}</th>
                     <th scope="col">{{ 'Mod list description'|trans }}</th>
                     <th scope="col">{{ 'Mod list owner'|trans }}</th>
+                    <th scope="col">{{ 'Mod list active'|trans }}</th>
                     <th scope="col">{{ 'Created at'|trans }}</th>
                     <th scope="col">{{ 'Last updated at'|trans }}</th>
                     <th></th>
@@ -35,6 +36,7 @@
                         <td>{{ modList.name }}</td>
                         <td>{{ modList.description }}</td>
                         <td>{{ modList.owner ? modList.owner.username : '' }}</td>
+                        <td>{{ modList.active ? 'Yes'|trans : 'No'|trans }}</td>
                         <td>{{ tableMacro.row_blameable(modList.createdAt, modList.createdBy) }}</td>
                         <td>{{ tableMacro.row_blameable(modList.lastUpdatedAt, modList.lastUpdatedBy) }}</td>
                         <td class="text-right">

--- a/translations/messages.pl.yaml
+++ b/translations/messages.pl.yaml
@@ -109,6 +109,7 @@ Delete mod list: Usuń listę modów
 Mod list name: Nazwa listy modów
 Mod list description: Opis listy modów
 Mod list owner: Właściciel listy modów
+Mod list active: Aktywna
 
 # Mod Lists Customization
 Mod list customization: Konfiguracja listy modów
@@ -121,6 +122,8 @@ Try again later: Spróbuj ponownie później
 # Common
 Apply: Zastosuj
 Cancel: Anuluj
+Yes: Tak
+No: Nie
 Download: Pobierz
 Created at: Utworzono
 Created by: Utworzono przez


### PR DESCRIPTION
This will:
* Add option to enable/disable each Mod List.

By default Mod Lists are active.
Deactivated Mod Lists are not displayed on download page.
Deactivated Mod Lists cannot be downloaded by anonymous users. Logged-in users need "List" permission to download them from list of all Mod Lists.