### PR TITLE
Improve xdebug config to enable console commands debugging

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -128,6 +128,8 @@ CMD ["nginx", "-g", "daemon off;"]
 
 FROM armaforces_web_php AS armaforces_web_php_dev
 
+ENV XDEBUG_INI_PATH=/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
 ARG XDEBUG_VERSION=2.9.6
 RUN set -eux; \
     apk add --no-cache --virtual .build-deps $PHPIZE_DEPS; \
@@ -138,3 +140,7 @@ RUN set -eux; \
 RUN apk add --no-cache \
         nodejs \
         npm
+
+COPY .docker/php/scripts/xon.sh /usr/bin/xon
+COPY .docker/php/scripts/xoff.sh /usr/bin/xoff
+RUN chmod +x /usr/bin/xon /usr/bin/xoff

--- a/.docker/php/docker-entrypoint.sh
+++ b/.docker/php/docker-entrypoint.sh
@@ -26,7 +26,25 @@ fi
 
 # Update xdebug config if exists
 if test -f "$XDEBUG_INI_PATH"; then
-    printf '%s\n' 'xdebug.remote_enable=0' 'xdebug.remote_host=' 'xdebug.remote_port=9097' 'xdebug.remote_autostart=1' >> $XDEBUG_INI_PATH
+    # https://github.com/qoomon/docker-host/blob/master/entrypoint.sh
+    function resolveHost {
+        getent ahostsv4 "$1" | head -n1 | cut -d' ' -f1
+    }
+    DOCKER_HOST='host.docker.internal'
+    docker_host_ip="$(resolveHost "$DOCKER_HOST")"
+
+    if [ "$docker_host_ip" ]
+    then
+        echo "Docker Host: $docker_host_ip ($DOCKER_HOST)"
+    else
+        docker_host_ip=$(ip -4 route show default | cut -d' ' -f3)
+        if [ "$docker_host_ip" ]
+        then
+            echo "Docker Host: $docker_host_ip (default gateway)"
+        fi
+    fi
+
+    printf '%s\n' 'xdebug.remote_enable=0' "xdebug.remote_host=${docker_host_ip}" 'xdebug.remote_port=9097' 'xdebug.remote_autostart=1' >> $XDEBUG_INI_PATH
 fi
 
 exec docker-php-entrypoint "$@"

--- a/.docker/php/docker-entrypoint.sh
+++ b/.docker/php/docker-entrypoint.sh
@@ -24,4 +24,9 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
     fi
 fi
 
+# Update xdebug config if exists
+if test -f "$XDEBUG_INI_PATH"; then
+    printf '%s\n' 'xdebug.remote_enable=0' 'xdebug.remote_host=' 'xdebug.remote_port=9097' 'xdebug.remote_autostart=1' >> $XDEBUG_INI_PATH
+fi
+
 exec docker-php-entrypoint "$@"

--- a/.docker/php/scripts/xoff.sh
+++ b/.docker/php/scripts/xoff.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+sed -i "s|xdebug.remote_enable=.*|xdebug.remote_enable=0|" $XDEBUG_INI_PATH
+echo "XDEBUG OFF"
+
+pkill -USR2 -o php-fpm

--- a/.docker/php/scripts/xon.sh
+++ b/.docker/php/scripts/xon.sh
@@ -4,7 +4,6 @@ set -e
 HOST_IP=$(/sbin/ip route | awk '/default/ { print $3 }')
 
 sed -i "s|xdebug.remote_enable=.*|xdebug.remote_enable=1|" $XDEBUG_INI_PATH
-sed -i "s|xdebug.remote_host=.*|xdebug.remote_host=$HOST_IP|" $XDEBUG_INI_PATH
 echo "XDEBUG ON"
 
 pkill -USR2 -o php-fpm

--- a/.docker/php/scripts/xon.sh
+++ b/.docker/php/scripts/xon.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+HOST_IP=$(/sbin/ip route | awk '/default/ { print $3 }')
+
+sed -i "s|xdebug.remote_enable=.*|xdebug.remote_enable=1|" $XDEBUG_INI_PATH
+sed -i "s|xdebug.remote_host=.*|xdebug.remote_host=$HOST_IP|" $XDEBUG_INI_PATH
+echo "XDEBUG ON"
+
+pkill -USR2 -o php-fpm

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,12 +8,6 @@ services:
         volumes:
             - './:/www/app:rw'
         environment:
-            XDEBUG_CONFIG: >-
-                remote_enable=1
-                remote_autostart=0
-                remote_host=host.docker.internal
-                remote_port=9097
-                idekey=PHPSTORM
             # This should correspond to the server declared in PHPStorm `Preferences | Languages & Frameworks | PHP | Servers`
             # Then PHPStorm will use the corresponding path mappings
             PHP_IDE_CONFIG: serverName=armaforces-web


### PR DESCRIPTION
This will:
* Add two scripts for turning xdebug on and off
* Move xdebug env var configuration from `docker-compose.yaml` to xdebug .ini file
* Allow us to debug HTTP requests as well as console commands without any extra configuration

Let me know if you see any downsides of this configuration and please check if it works on Windows (especially the HOST_IP part).