### PR TITLE
Add AF prefix to mod list file and launcher name

### DIFF
--- a/src/Controller/ModListPublicController.php
+++ b/src/Controller/ModListPublicController.php
@@ -67,18 +67,19 @@ class ModListPublicController extends AbstractController
      */
     public function downloadAction(ModList $modList, string $optionalModsJson = null): Response
     {
-        $fileName = sprintf('%s %s.html', $modList->getName(), (new \DateTimeImmutable())->format('Y-m-d H-i-s'));
+        $name = sprintf('AF %s %s.html', $modList->getName(), (new \DateTimeImmutable())->format('Y-m-d H-i-s'));
         $mods = $this->modRepository->findIncludedSteamWorkshopMods($modList);
         $optionalMods = json_decode($optionalModsJson ?? '', true) ?: [];
 
         $template = $this->renderView('mod_list_public/launcher_preset_template.html.twig', [
+            'name' => $name,
             'modList' => $modList,
             'mods' => $mods,
             'optionalMods' => $optionalMods,
         ]);
 
         return new Response($template, Response::HTTP_OK, [
-            'Content-Disposition' => HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $fileName),
+            'Content-Disposition' => HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, $name),
         ]);
     }
 }

--- a/src/Test/Traits/AssertsTrait.php
+++ b/src/Test/Traits/AssertsTrait.php
@@ -22,7 +22,7 @@ trait AssertsTrait
     public static function assertResponseContainsModListAttachmentHeader(Response $response, ModList $modList): void
     {
         $contentDispositionHeader = $response->headers->get('Content-Disposition');
-        $pattern = "/^attachment; filename=\"{$modList->getName()} \\d{4}-\\d{2}-\\d{2} \\d{2}-\\d{2}-\\d{2}.html\"$/";
+        $pattern = "/^attachment; filename=\"AF {$modList->getName()} \\d{4}-\\d{2}-\\d{2} \\d{2}-\\d{2}-\\d{2}.html\"$/";
 
         self::assertTrue(1 === preg_match($pattern, $contentDispositionHeader));
     }

--- a/templates/mod_list_public/launcher_preset_template.html.twig
+++ b/templates/mod_list_public/launcher_preset_template.html.twig
@@ -2,14 +2,14 @@
 <html>
     <head>
         <meta name="arma:Type" content="preset"/>
-        <meta name="arma:PresetName" content="{{ modList.name }}"/>
+        <meta name="arma:PresetName" content="{{ name }}"/>
         <meta name="generator" content="{{ global.app.organization ~ ' - ' ~ global.app.url.website }}"/>
         <title>{{ modList.name }}</title>
         <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css"/>
         <link rel="stylesheet" media="all" href="http://modlist.armaforces.com/static/launcher.css"/>
     </head>
     <body>
-        <h1>Arma 3 Mods - Preset <strong>{{ modList.name }}</strong></h1>
+        <h1>Arma 3 Mods - Preset <strong>{{ name }}</strong></h1>
         <p class="before-list">
             <em>Drag this file or link to it into Arma 3 Launcher, or open it - Mods / Preset / Import.</em>
         </p>


### PR DESCRIPTION
This will:
* Add `AF` prefix to both mod list filename and launcher name
* Restore download date in mod list launcher name

Closes: #195