### PR TITLE
Skip validation of private and unlisted mods

### DIFF
--- a/src/Form/Mod/Dto/ModFormDto.php
+++ b/src/Form/Mod/Dto/ModFormDto.php
@@ -14,8 +14,9 @@ use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * @UniqueSteamWorkshopMod(groups={ModSourceEnum::STEAM_WORKSHOP}))
- * @UniqueDirectoryMod(groups={ModSourceEnum::DIRECTORY}))
+ * @UniqueSteamWorkshopMod(groups={ModSourceEnum::STEAM_WORKSHOP})
+ * @SteamWorkshopArma3ModUrl(groups={ModSourceEnum::STEAM_WORKSHOP}, errorPath="url", nameErrorPath="name")
+ * @UniqueDirectoryMod(groups={ModSourceEnum::DIRECTORY})
  */
 class ModFormDto extends AbstractFormDto
 {
@@ -51,7 +52,6 @@ class ModFormDto extends AbstractFormDto
     /**
      * @Assert\NotBlank(groups={ModSourceEnum::STEAM_WORKSHOP})
      * @Assert\Length(min=1, max=255, groups={ModSourceEnum::STEAM_WORKSHOP})
-     * @SteamWorkshopArma3ModUrl(groups={ModSourceEnum::STEAM_WORKSHOP}))
      */
     protected ?string $url = null;
 

--- a/src/Service/SteamWorkshop/Dto/SteamWorkshopItemInfoDto.php
+++ b/src/Service/SteamWorkshop/Dto/SteamWorkshopItemInfoDto.php
@@ -6,28 +6,28 @@ namespace App\Service\SteamWorkshop\Dto;
 
 class SteamWorkshopItemInfoDto
 {
-    protected int $id;
-    protected string $name;
-    protected int $gameId;
+    protected ?int $id;
+    protected ?string $name;
+    protected ?int $gameId;
 
-    public function __construct(int $id, string $name, int $gameId)
+    public function __construct(?int $id, ?string $name, ?int $gameId)
     {
         $this->id = $id;
         $this->name = $name;
         $this->gameId = $gameId;
     }
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getGameId(): int
+    public function getGameId(): ?int
     {
         return $this->gameId;
     }

--- a/src/Service/SteamWorkshop/SteamWorkshopClient.php
+++ b/src/Service/SteamWorkshop/SteamWorkshopClient.php
@@ -37,9 +37,9 @@ class SteamWorkshopClient
             throw new ItemNotFoundException(sprintf('No items found by item id "%s"!', $itemId));
         }
 
-        $publishedFileDetails = $responseKey['publishedfiledetails'][0];
-        $itemName = $publishedFileDetails['title'];
-        $gameId = $publishedFileDetails['creator_app_id'];
+        $publishedFileDetails = $responseKey['publishedfiledetails'][0] ?? null;
+        $itemName = $publishedFileDetails['title'] ?? null;
+        $gameId = $publishedFileDetails['creator_app_id'] ?? null;
 
         return new SteamWorkshopItemInfoDto($itemId, $itemName, $gameId);
     }

--- a/src/Validator/Mod/SteamWorkshopArma3ModUrl.php
+++ b/src/Validator/Mod/SteamWorkshopArma3ModUrl.php
@@ -14,12 +14,12 @@ class SteamWorkshopArma3ModUrl extends Constraint
     public string $invalidModUrlMessage = 'Invalid Steam Workshop mod URL';
     public string $modNotFoundMessage = 'Mod not found';
     public string $notAnArma3ModMessage = 'Mod is not an Arma 3 mod';
+    public string $modIsPrivateOrMissingDetails = 'Mod is either private or missing required details';
+    public ?string $errorPath = null;
+    public ?string $nameErrorPath = null;
 
-    /**
-     * @return string[]
-     */
-    public function getRequiredOptions(): array
+    public function getTargets()
     {
-        return [];
+        return parent::CLASS_CONSTRAINT;
     }
 }

--- a/src/Validator/Mod/UniqueDirectoryMod.php
+++ b/src/Validator/Mod/UniqueDirectoryMod.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraint;
 class UniqueDirectoryMod extends Constraint
 {
     public string $message = 'Mod associated with directory "{{ directoryName }}" already exist';
-    public ?string $errorPath;
+    public ?string $errorPath = null;
 
     public function getTargets()
     {

--- a/src/Validator/Mod/UniqueSteamWorkshopMod.php
+++ b/src/Validator/Mod/UniqueSteamWorkshopMod.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraint;
 class UniqueSteamWorkshopMod extends Constraint
 {
     public string $message = 'Mod associated with url "{{ modUrl }}" already exist';
-    public ?string $errorPath;
+    public ?string $errorPath = null;
 
     public function getTargets()
     {

--- a/src/Validator/ModGroup/UniqueModGroupName.php
+++ b/src/Validator/ModGroup/UniqueModGroupName.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraint;
 class UniqueModGroupName extends Constraint
 {
     public string $message = 'Mod group with the same name "{{ modGroupName }}" already exist';
-    public ?string $errorPath;
+    public ?string $errorPath = null;
 
     public function getTargets()
     {

--- a/translations/validators.pl.yaml
+++ b/translations/validators.pl.yaml
@@ -8,6 +8,7 @@ Mod associated with directory "{{ directoryName }}" already exist: Mod znajdują
 Invalid Steam Workshop mod URL: Błędny link do moda
 Mod not found: Nie znaleziono moda
 Mod is not an Arma 3 mod: Mod nie jest modem do Arma 3
+Mod is either private or missing required details: Mod jest prywatny lub nie zawiera niezbędnych do jego dodania informacji
 
 # Windows Directory Name Validator
 Invalid directory name: Błędny format nazwy katalogu


### PR DESCRIPTION
This will:
* Validate game id only when returned by the Steam API. This will allow adding private/unlisted mods.
* Require mod name if cannot be obtained from the Steam API

Closes: #194