### PR TITLE
Add ArmaForces organization GitHub link icon to navbar

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -27,6 +27,7 @@ twig:
                     teamspeak: '%app.url.teamspeak%'
                     calendar: 'https://docs.google.com/spreadsheets/d/1t1158AsoxIwXI5FlPNjqbaXk6Cx7oq7Ocgchnsk2_TE'
                     github: 'https://github.com/ArmaForces/Website'
+                    github_af: 'https://github.com/ArmaForces'
 
 when@test:
     twig:

--- a/templates/_partial/navbar/_navbar_icons.html.twig
+++ b/templates/_partial/navbar/_navbar_icons.html.twig
@@ -1,5 +1,13 @@
 <!-- Icons -->
 <ul class="navbar-nav nav-icons">
+    <!-- GitHub -->
+    <li class="nav-item">
+        <a href="{{ global.app.url.github }}" target="_blank" class="nav-link">
+            <i class="fab fa-github"></i>
+        </a>
+    </li>
+    <!--/ GitHub -->
+
     <!-- Discord -->
     <li class="nav-item">
         <a href="{{ global.app.url.discord }}" target="_blank" class="nav-link">

--- a/templates/_partial/navbar/_navbar_icons.html.twig
+++ b/templates/_partial/navbar/_navbar_icons.html.twig
@@ -2,8 +2,8 @@
 <ul class="navbar-nav nav-icons">
     <!-- GitHub -->
     <li class="nav-item">
-        <a href="{{ global.app.url.github }}" target="_blank" class="nav-link">
-            <i class="fab fa-github"></i>
+        <a href="{{ global.app.url.github_af }}" target="_blank" class="nav-link">
+            <i class="fab fa-github_af"></i>
         </a>
     </li>
     <!--/ GitHub -->

--- a/templates/_partial/navbar/_navbar_icons.html.twig
+++ b/templates/_partial/navbar/_navbar_icons.html.twig
@@ -3,7 +3,7 @@
     <!-- GitHub -->
     <li class="nav-item">
         <a href="{{ global.app.url.github_af }}" target="_blank" class="nav-link">
-            <i class="fab fa-github_af"></i>
+            <i class="fab fa-github"></i>
         </a>
     </li>
     <!--/ GitHub -->


### PR DESCRIPTION
I thought about adding a GitHub link at the top of the page, just like there are Discord, Steam and TeamSpeak icons already.

I suppose adding that to `_navbar_icons.html.twig` is not enough and I'd appreciate some help as I couldn't figure the rest myself.