### PR TITLE
Tests - Wait for services to be ready in detached mode

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -26,8 +26,8 @@ jobs:
 
             -   name: Start stack
                 run: |
-                    docker-compose -f docker-compose.test.yml up --wait
-                    docker-compose exec -T php composer install
+                    docker compose -f docker-compose.test.yml up --wait
+                    docker compose exec -T php composer install
 
             -   name: Setup database
                 run: |
@@ -35,7 +35,7 @@ jobs:
 
             -   name: Run lint
                 run: |
-                    docker-compose exec -T php bin/console cache:warmup --env=dev
+                    docker compose exec -T php bin/console cache:warmup --env=dev
                     make cs env=test ci=true
 
             -   name: Run tests

--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -26,7 +26,7 @@ jobs:
 
             -   name: Start stack
                 run: |
-                    docker-compose -f docker-compose.test.yml up -d
+                    docker-compose -f docker-compose.test.yml up --wait
                     docker-compose exec -T php composer install
 
             -   name: Setup database


### PR DESCRIPTION
```
--wait     Wait for services to be running|healthy. Implies detached mode.
```

Should fix the rare issue where tests fail due to DB container taking too long to start up.