### PR TITLE
Disable mod source change on edit

### DIFF
--- a/src/Form/Mod/ModFormType.php
+++ b/src/Form/Mod/ModFormType.php
@@ -27,9 +27,14 @@ class ModFormType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        /** @var ModFormDto $modFormDto */
+        $modFormDto = $options['data'];
+        $modExists = null !== $modFormDto->getId();
+
         $builder
             ->add('source', ChoiceType::class, [
                 'label' => 'Mod source',
+                'disabled' => $modExists,
                 'choices' => [
                     'Steam Workshop' => ModSourceEnum::STEAM_WORKSHOP->value,
                     'Directory' => ModSourceEnum::DIRECTORY->value,


### PR DESCRIPTION
This will:
- Disable mod source select list on mod edit as it doesn't make sense to change Steam Workshop mod to Directory mod and vice versa and it was never fully supported when mod was assigned to groups or lists.