### PR TITLE
Remove recreate mod when changing mod type

### DIFF
--- a/src/Controller/Mod/UpdateAction.php
+++ b/src/Controller/Mod/UpdateAction.php
@@ -33,12 +33,7 @@ class UpdateAction extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $updatedMod = $this->dataTransformerRegistry->transformToEntity($modFormDto, $mod);
-
-            if (!$this->entityManager->contains($updatedMod)) {
-                $this->entityManager->remove($mod);
-                $this->entityManager->persist($updatedMod);
-            }
+            $this->dataTransformerRegistry->transformToEntity($modFormDto, $mod);
 
             $this->entityManager->flush();
 


### PR DESCRIPTION
This will:
- title
This is no longer needed as mod type cannot be changed on edit form